### PR TITLE
Disable unsupported mysql modes before update the mysql database

### DIFF
--- a/main.py
+++ b/main.py
@@ -143,6 +143,7 @@ def construct_actions(options: typing.Any, stage_flag: Stages) -> typing.Dict[in
             actions.DisablePleskSshBanner(),
             actions.RepairPleskInstallation(),
             actions.DisableMariadbInnodbFastShutdown(),
+            actions.DisableUnsupportedMysqlModes(),
             actions.InstallUbuntuUpdateManager(),
             actions.CleanApparmorCacheConfig(),
             actions.RestoreCurrentSpamassasinConfiguration(),
@@ -155,7 +156,6 @@ def construct_actions(options: typing.Any, stage_flag: Stages) -> typing.Dict[in
         2: [
             actions.InstallNextKernelVersion(),
             actions.InstallUbuntu20Mariadb(),
-            actions.InstallUbuntu20Mysql(),
             actions.InstallUdev(),
             actions.ReinstallSystemd(),
             actions.RemoveLXD(),


### PR DESCRIPTION
There are list of modes that was deprecated:
- ONLY_FULL_GROUP_BY,
- STRICT_TRANS_TABLES,
- NO_ZERO_IN_DATE,
- NO_ZERO_DATE,
- ERROR_FOR_DIVISION_BY_ZERO,
- NO_AUTO_CREATE_USER,
- NO_ENGINE_SUBSTITUTION,

And they was completly removed in MySQL 8.
So we have to remove them when moveing from MySQL 5.3 to MySQL 8.