### PR TITLE
TuxCare ELS support, update submodule

### DIFF
--- a/ubuntu18to20/actions/__init__.py
+++ b/ubuntu18to20/actions/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024. WebPros International GmbH. All rights reserved.
+from .packages import *

--- a/ubuntu18to20/actions/packages.py
+++ b/ubuntu18to20/actions/packages.py
@@ -1,0 +1,33 @@
+# Copyright 2024. WebPros International GmbH. All rights reserved.
+from pleskdistup.common import action, packages
+
+
+class RemoveUnusedPackages(action.ActiveAction):
+    """ Removes packages that are not used anymore in the target OS after the dist-upgrade.
+        These are mostly versioned packages, which have corresponding alternatives in the
+        target OS with a different package name, which makes these ones obsolete and useless.
+        The alternatives are expected to have been installed by the dist-upgrade itself.
+    """
+
+    def __init__(self):
+        self.name = "remove unused packages"
+        self.unused_packages = [
+            "libmagickcore-6.q16-3",
+            "libmagickwand-6.q16-3",
+            "libmysqlclient20",
+            "libprocps6",
+            "perl-modules-5.26",
+        ]
+
+    def _prepare_action(self) -> action.ActionResult:
+        return action.ActionResult()
+
+    def _post_action(self) -> action.ActionResult:
+        packages.remove_packages(packages.filter_installed_packages(self.unused_packages))
+        return action.ActionResult()
+
+    def _revert_action(self) -> action.ActionResult:
+        return action.ActionResult()
+
+    def estimate_post_time(self) -> int:
+        return 5

--- a/ubuntu18to20/upgrader.py
+++ b/ubuntu18to20/upgrader.py
@@ -10,6 +10,7 @@ from pleskdistup.phase import Phase
 from pleskdistup.upgrader import dist, DistUpgrader, DistUpgraderFactory, PathType
 
 import ubuntu18to20.config
+import ubuntu18to20.actions
 
 
 class Ubuntu18to20Upgrader(DistUpgrader):
@@ -102,6 +103,7 @@ class Ubuntu18to20Upgrader(DistUpgrader):
             ],
             "Dist-upgrade": [
                 actions.DoDistupgrade(),
+                ubuntu18to20.actions.RemoveUnusedPackages(),
             ],
             "Finishing actions": [
                 actions.Reboot(prepare_next_phase=Phase.FINISH, name="reboot and perform finishing actions"),

--- a/ubuntu18to20/upgrader.py
+++ b/ubuntu18to20/upgrader.py
@@ -86,6 +86,7 @@ class Ubuntu18to20Upgrader(DistUpgrader):
                 actions.AddInProgressSshLoginMessage(new_os),
                 actions.DisablePleskSshBanner(),
                 actions.RepairPleskInstallation(),  # Executed at the finish phase only
+                actions.UninstallTuxcareEls(),
                 actions.DisableMariadbInnodbFastShutdown(),
                 actions.DisableUnsupportedMysqlModes(),
                 actions.InstallUbuntuUpdateManager(),

--- a/ubuntu18to20/upgrader.py
+++ b/ubuntu18to20/upgrader.py
@@ -7,26 +7,20 @@ import typing
 from pleskdistup import actions
 from pleskdistup.common import action, feedback
 from pleskdistup.phase import Phase
-from pleskdistup.upgrader import DistUpgrader, DistUpgraderFactory, PathType, SystemDescription
+from pleskdistup.upgrader import dist, DistUpgrader, DistUpgraderFactory, PathType
 
 import ubuntu18to20.config
 
 
 class Ubuntu18to20Upgrader(DistUpgrader):
-    _os_from_name = "Ubuntu"
-    _os_from_version = "18"
-    _os_to_name = "Ubuntu"
-    _os_to_version = "20"
+    _distro_from = dist.Ubuntu("18")
+    _distro_to = dist.Ubuntu("20")
 
     def __init__(self):
         super().__init__()
 
     def __repr__(self) -> str:
-        attrs = ", ".join(f"{k}={getattr(self, k)!r}" for k in (
-            "_os_from_name", "_os_from_version",
-            "_os_to_name", "_os_to_version",
-        ))
-        return f"{self.__class__.__name__}({attrs})"
+        return f"{self.__class__.__name__}(From {self._distro_from}, To {self._distro_to})"
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}"
@@ -34,18 +28,12 @@ class Ubuntu18to20Upgrader(DistUpgrader):
     @classmethod
     def supports(
         cls,
-        from_system: typing.Optional[SystemDescription] = None,
-        to_system: typing.Optional[SystemDescription] = None
+        from_system: typing.Optional[dist.Distro] = None,
+        to_system: typing.Optional[dist.Distro] = None
     ) -> bool:
-        def matching_system(system: SystemDescription, os_name: str, os_version: str) -> bool:
-            return (
-                (system.os_name is None or system.os_name == os_name)
-                and (system.os_version is None or system.os_version == os_version)
-            )
-
         return (
-            (from_system is None or matching_system(from_system, cls._os_from_name, cls._os_from_version))
-            and (to_system is None or matching_system(to_system, cls._os_to_name, cls._os_to_version))
+            (from_system is None or cls._distro_from == from_system)
+            and (to_system is None or cls._distro_to == to_system)
         )
 
     @property
@@ -78,7 +66,7 @@ class Ubuntu18to20Upgrader(DistUpgrader):
         options: typing.Any,
         phase: Phase
     ) -> typing.Dict[str, typing.List[action.ActiveAction]]:
-        new_os = f"{self._os_to_name} {self._os_to_version}"
+        new_os = str(self._distro_to)
         return {
             "Prepare": [
                 actions.HandleConversionStatus(options.status_flag_path, options.completion_flag_path),
@@ -135,7 +123,7 @@ class Ubuntu18to20Upgrader(DistUpgrader):
         ]
 
     def parse_args(self, args: typing.Sequence[str]) -> None:
-        DESC_MESSAGE = f"""Use this upgrader to dist-upgrade an {self._os_from_name} {self._os_from_version} server with Plesk to {self._os_to_name} {self._os_to_version}. The process consists of the following general stages:
+        DESC_MESSAGE = f"""Use this upgrader to dist-upgrade an {self._distro_from} server with Plesk to {self._distro_to}. The process consists of the following general stages:
 
 -- Preparation (about 5 minutes) - The OS is prepared for the conversion.
 -- Conversion (about 15 minutes) - Plesk and system dist-upgrade is performed.
@@ -174,8 +162,8 @@ class Ubuntu18to20Factory(DistUpgraderFactory):
 
     def supports(
         self,
-        from_system: typing.Optional[SystemDescription] = None,
-        to_system: typing.Optional[SystemDescription] = None
+        from_system: typing.Optional[dist.Distro] = None,
+        to_system: typing.Optional[dist.Distro] = None
     ) -> bool:
         return Ubuntu18to20Upgrader.supports(from_system, to_system)
 


### PR DESCRIPTION
PPP-64910. This will need to be released with or before Plesk 18.0.62.

Depends on https://github.com/plesk/dist-upgrader/pull/39

Not sure if we want to remove excessive packages after dist-upgrade. These are the following, except `ca-certificates`:
```
ii  ca-certificates                       20231207ubuntu0.18.04.1+tuxcare.els1              all          Common CA certificates
ii  libmagickcore-6.q16-3:amd64           8:6.9.7.4+dfsg-16ubuntu6.15+tuxcare.els4          amd64        low-level image manipulation library -- quantum depth Q16
ii  libmagickwand-6.q16-3:amd64           8:6.9.7.4+dfsg-16ubuntu6.15+tuxcare.els4          amd64        image manipulation library -- quantum depth Q16
ii  libmysqlclient20:amd64                5.7.44-0ubuntu0.18.04.1+tuxcare.els1              amd64        MySQL database client library
ii  libprocps6:amd64                      2:3.3.12-3ubuntu1.2+tuxcare.els1                  amd64        library for accessing process information from /proc
ii  perl-modules-5.26                     5.26.1-6ubuntu0.7+tuxcare.els1                    all          Core Perl modules
```

Proper generic solution seems to be rather involved and the set of packages may be larger as a result of ELS updates. So I think we should leave this to the user. Note that these packages are unused and their presence is not harmful.

_Edit:_ excessive packages are now removed.