### PR TITLE
Temporarily remove python-gi before dist-upgrade and reinstall afterward

### DIFF
--- a/ubuntu18to20/upgrader.py
+++ b/ubuntu18to20/upgrader.py
@@ -91,6 +91,7 @@ class Ubuntu18to20Upgrader(DistUpgrader):
                 actions.AddUpgradeSystemdService(os.path.abspath(upgrader_bin_path), options),
                 actions.MoveOldBindConfigToNamed(),
                 actions.RemoveMailComponents(options.state_dir),
+                actions.TemporaryRemovePackage("python-gi"),
             ],
             "Switch repositories": [
                 # UpdateLegacyPhpRepositories specific for distupgrades where


### PR DESCRIPTION
The Ubuntu do-release-upgrade tool fails to upgrade python-gi due to issues related to the Python 2.7 upgrade during the process. To avoid this conflict, the package is removed before the upgrade and reinstalled once the upgrade is complete.

Related issue is #25